### PR TITLE
fix with no-op function

### DIFF
--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -51,7 +51,12 @@ export class Api {
     });
   }
 
+  noOp() {
+    return;
+  }
+
   async getToken() {
+    await this.noOp();
     const token = await this.instance.acquireTokenSilent({
       scopes: [
         'https://turplanlegger.onmicrosoft.com/0149fc65-259e-4895-9034-e144c242f733/Default'


### PR DESCRIPTION
Fjerner warning fra konsoll. Tror det er en race-condition mellom msal og recoil, warning kommer ikke dersom man venter noen millisekunder (kaller og awaiter en funksjon som ikke gjør noe)

Warning: Cannot update a component (`MsalProvider`) while rendering a different component (`Lists`). To locate the bad setState() call inside `Lists`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
Lists@http://localhost:3000/static/js/bundle.js:1730:76